### PR TITLE
Add Music support.

### DIFF
--- a/lib/DayOneEntry.js
+++ b/lib/DayOneEntry.js
@@ -7,6 +7,7 @@ function DayOneEntry() {
     this.tags = [];
     this.timezone = 'Europe/Berlin';
     this.starred = false;
+    this.music = {};
 }
 
 DayOneEntry.prototype.toOutputFormat = function toOutputFormat() {
@@ -20,7 +21,8 @@ DayOneEntry.prototype.toOutputFormat = function toOutputFormat() {
         "Entry Text": this.text,
         "Tags": this.tags,
         "Time Zone": this.timezone,
-        "Starred": this.starred
+        "Starred": this.starred,
+        "Music": this.music
     };
 
     return plist.build(entry);
@@ -41,6 +43,10 @@ DayOneEntry.prototype.fromFile = function fromOutputFormat(filename) {
 
     if(entry['Tags']) {
         this.tags = entry['Tags'];
+    }
+
+    if (entry['Music']) {
+        this.music = entry['Music'];
     }
 
     return this;

--- a/test/DayOneEntry.js
+++ b/test/DayOneEntry.js
@@ -17,6 +17,11 @@ describe('DayOneEntry', function() {
             entry.starred = true;
             entry.creationDate = new Date(1371940000000);
             entry.timezone = 'Europe/Paris';
+            entry.music = {
+                Album: 'AM',
+                Artist: 'Arctic Monkeys',
+                Track: 'Do I Wanna Know?'
+            };
 
             var outPlist = entry.toOutputFormat();
 
@@ -28,6 +33,7 @@ describe('DayOneEntry', function() {
             assert.equal(parsed['Starred'], entry.starred);
             assert.equal(parsed['Creation Date'].getTime(), entry.creationDate.getTime());
             assert.equal(parsed['Time Zone'], entry.timezone);
+            assert.deepEqual(parsed['Music'], entry.music);
 
             done();
         });


### PR DESCRIPTION
Add support for the Music metadata added in [Day One 1.12](http://dayoneapp.com/2013/11/day-one-ios-7-redesign/).
