### PR TITLE
Handling empty parse argument

### DIFF
--- a/lib/DayOneEntry.js
+++ b/lib/DayOneEntry.js
@@ -54,8 +54,14 @@ DayOneEntry.prototype.fromFile = function fromOutputFormat(filename) {
     if (!fs.existsSync(filename)) {
         return null;
     }
-
-    var entry = plist.parse(fs.readFileSync(filename, 'utf8'));
+    
+    var file = fs.readFileSync(filename, 'utf8');
+    
+    if (!file) {
+        return null;
+    }
+    
+    var entry = plist.parse(file);
 
     if(!entry) {
         return null;


### PR DESCRIPTION
fs.readFileSync(filename, 'utf8') may be null in some case. Here is to avoid this