### PR TITLE
update plist package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "test": "mocha --reporter spec"
   },
   "dependencies": {
-    "path-extra": "0.2.1",
-    "moment": "2.8.1",
     "hat": "0.0.3",
-    "plist": "1.0.1"
+    "moment": "2.8.1",
+    "path-extra": "0.2.1",
+    "plist": "^1.2.0"
   },
   "devDependencies": {
     "mocha": "*"
@@ -27,6 +27,5 @@
     "email": "ich@philippwaldhauer.de",
     "url": "http://knuspermagier.de"
   },
-
   "license": "MIT"
 }


### PR DESCRIPTION
Updating the Plist package fixes a TypeError I was getting. Tests still pass.

``` js
if (doc.documentElement.nodeName !== 'plist') {
         ^

TypeError: Cannot read property 'documentElement' of undefined
```
